### PR TITLE
Added feature to automatically download default model weights into working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ pip install --upgrade pip
 ```
 pip install -r requirements.txt
 ```
-- Download [yolov7](https://github.com/WongKinYiu/yolov7/releases/download/v0.1/yolov7.pt) object detection weights from link and move them to the working directory {yolov7-object-tracking}
-- Run the code with mentioned command below.
+- Run the code with mentioned command below (by default, pretrained [yolov7](https://github.com/WongKinYiu/yolov7/releases/download/v0.1/yolov7.pt) weights will be automatically downloaded into the working directory if they don't already exist).
 ```
 #if you want to change source file
 python detect_and_track.py --weights yolov7.pt --source "your video.mp4"

--- a/detect_and_track.py
+++ b/detect_and_track.py
@@ -14,6 +14,7 @@ from utils.general import check_img_size, check_requirements, \
                 increment_path
 from utils.plots import plot_one_box
 from utils.torch_utils import select_device, load_classifier, time_synchronized, TracedModel
+from utils.download_weights import download
 
 #For SORT tracking
 import skimage
@@ -249,6 +250,8 @@ def detect(save_img=False):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--weights', nargs='+', type=str, default='yolov7.pt', help='model.pt path(s)')
+    parser.add_argument('--download', action='store_true', help='download model weights automatically')
+    parser.add_argument('--no-download', dest='download', action='store_false')
     parser.add_argument('--source', type=str, default='inference/images', help='source')  # file/folder, 0 for webcam
     parser.add_argument('--img-size', type=int, default=640, help='inference size (pixels)')
     parser.add_argument('--conf-thres', type=float, default=0.25, help='object confidence threshold')
@@ -266,9 +269,13 @@ if __name__ == '__main__':
     parser.add_argument('--name', default='object_tracking', help='save results to project/name')
     parser.add_argument('--exist-ok', action='store_true', help='existing project/name ok, do not increment')
     parser.add_argument('--no-trace', action='store_true', help='don`t trace model')
+    parser.set_defaults(download=True)
     opt = parser.parse_args()
     print(opt)
     #check_requirements(exclude=('pycocotools', 'thop'))
+    if opt.download and not os.path.exists(opt.weights):
+        print('Model weights not found. Attempting to download now...')
+        download('./')
 
     with torch.no_grad():
         if opt.update:  # update all models (to fix SourceChangeWarning)

--- a/utils/download_weights.py
+++ b/utils/download_weights.py
@@ -1,0 +1,30 @@
+import os
+import requests
+from tqdm.auto import tqdm
+
+
+# Pre-trained weights for YoloV7 model
+WEIGHTS_URL = "https://github.com/WongKinYiu/yolov7/releases/download/v0.1/yolov7.pt"   # ?dl=1"
+
+
+def download(dest_path, url=None, file_name=None):
+    """ Download model weights to a destination path from a given url. """
+    url = url if url is not None else WEIGHTS_URL
+    resp = requests.get(url, stream=True)
+
+    os.makedirs(dest_path, exist_ok=True)
+    if not file_name:
+        file_name = os.path.basename(url)
+    output = os.path.abspath(os.path.join(dest_path, file_name))
+
+    total = int(resp.headers.get("content-length", 0))
+    with open(output, "wb") as file, tqdm(
+        desc=file_name,
+        total=total,
+        unit="iB",
+        unit_scale=True,
+        unit_divisor=1024,
+    ) as bar:
+        for data in resp.iter_content(chunk_size=1024):
+            size = file.write(data)
+            bar.update(size)


### PR DESCRIPTION
To make things easier for users, I added a feature to automatically download the YoloV7 network weights into the working directory if they don't already exist. README.md also updated to reflect this change.