### PR TITLE
Implemented --save-txt for tracked centroids and bounding boxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+runs/
+*/__pycache__/
+__pycache__
+weights/
+traced_model.pt

--- a/sort.py
+++ b/sort.py
@@ -99,9 +99,11 @@ class KalmanBoxTracker(object):
         CY = (bbox[1]+bbox[3])//2
         self.centroidarr.append((CX,CY))
         
-        
         #keep yolov5 detected class information
         self.detclass = bbox[5]
+
+        # If we want to store bbox
+        self.bbox_history = [bbox]
         
     def update(self, bbox):
         """
@@ -116,7 +118,8 @@ class KalmanBoxTracker(object):
         CX = (bbox[0]+bbox[2])//2
         CY = (bbox[1]+bbox[3])//2
         self.centroidarr.append((CX,CY))
-        
+        self.bbox_history.append(bbox)
+    
     def predict(self):
         """
         Advances the state vector and returns the predicted bounding box estimate


### PR DESCRIPTION
This pull request addresses #10 and features a basic implementation of saving tracked centroid information into text files in the generated `labels` directory.

I also attempted to implement saving the bounding box height and width along with the centroids, but I am unsure if how I calculated the bounding box dimensions are correct. Added the `--save-bbox-dim` argument flag to enable/disable the saving of bounding box information to the text files.

If there are any problems with how this was implemented, please let me know, as feedback is greatly appreciated. I had to attempt doing this since I needed the centroid information for a paper I'm writing that's urgently due.

Just as an illustration, here are the trajectories that I was able to extract using this codebase and the basic text file implementation:

<img width="549" alt="Screenshot 2022-11-14 at 1 14 37 AM" src="https://user-images.githubusercontent.com/60635460/201534748-eddeb117-247d-4497-b74e-900360a2f26d.png">

*Pardon the bounding boxes; I just chose a random frame to superimpose to. Pay attention to the red trajectories only.*

Thank you!