### PR TITLE
Update detect_and_track.py

### DIFF
--- a/detect_and_track.py
+++ b/detect_and_track.py
@@ -304,7 +304,7 @@ if __name__ == '__main__':
     opt = parser.parse_args()
     print(opt)
     #check_requirements(exclude=('pycocotools', 'thop'))
-    if opt.download and not os.path.exists(str(opt.weights)):
+    if opt.download and not os.path.exists(''.join(opt.weights)):
         print('Model weights not found. Attempting to download now...')
         download('./')
 


### PR DESCRIPTION
Bug doesn't allow to check if weights other than yolov7.pt exist, the path is always incorrect.