### PR TITLE
Remove `export` requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,19 +25,7 @@ tensorboard>=2.4.1
 pandas>=1.1.4
 seaborn>=0.11.0
 
-# Export --------------------------------------
-# coremltools>=4.1  # CoreML export
-# onnx>=1.9.0  # ONNX export
-# onnx-simplifier>=0.3.6  # ONNX simplifier
-# scikit-learn==0.19.2  # CoreML quantization
-# tensorflow>=2.4.1  # TFLite export
-# tensorflowjs>=3.9.0  # TF.js export
-# openvino-dev  # OpenVINO export
-
 # Extras --------------------------------------
 ipython  # interactive notebook
 psutil  # system utilization
 thop  # FLOPs computation
-# albumentations>=1.0.3
-# pycocotools>=2.0  # COCO mAP
-# roboflow


### PR DESCRIPTION
This PR removes the export requirements, as they are not needed for simple object detection and tracking.